### PR TITLE
Fix unresolved Promise and readonly property

### DIFF
--- a/src/app/pages/history/history.component.ts
+++ b/src/app/pages/history/history.component.ts
@@ -163,24 +163,22 @@ export class HistoryComponent implements OnInit {
   }
 
   async ngOnInit() {
-    await this.fetchTasks();
+    this.fetchTasks();
   }
 
-  public fetchTasks(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const data = this.history?.tasks || [];
-      this.new = data.filter((task) => task.type === 0);
-      this.active = data.filter((task) => task.type === 1);
-      this.closed = data.filter((task) => task.type === 2);
-    });
+  public fetchTasks(): void {
+    const data = this.history?.tasks || [];
+    this.new = data.filter((task) => task.type === 0);
+    this.active = data.filter((task) => task.type === 1);
+    this.closed = data.filter((task) => task.type === 2);
   }
 
   public reloadTaskHistory(): Promise<void> {
     return new Promise((resolve, reject) => {
       this._dataService.get<IHistory>(`history/${this.history?.id}`).subscribe({
-        next: async (history) => {
+        next: (history) => {
           this.history!.tasks = history.tasks;
-          await this.fetchTasks();
+          this.fetchTasks();
           resolve();
         },
         error: (error) => {

--- a/src/app/shared/services/data.service.ts
+++ b/src/app/shared/services/data.service.ts
@@ -7,12 +7,8 @@ import {Observable} from "rxjs";
   providedIn: 'root'
 })
 export class DataService {
-  private readonly _API_URL: string = '';
+  private readonly _API_URL: string = environment.apiUrl;
   private _http = inject(HttpClient);
-
-  constructor() {
-    this._API_URL = environment.apiUrl;
-  }
 
   public get<T>(path: string): Observable<T> {
     return this._http.get<T>(`${this._API_URL}${path}`);


### PR DESCRIPTION
## Summary
- remove unnecessary Promise in `fetchTasks` and adjust usage
- initialize API URL directly in `DataService`

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484148b98883238498d14c51d469e4